### PR TITLE
Bug 979595 - SIGFPE/hang in emulated camera on rapid start and stop, r=mwu

### DIFF
--- a/tools/emulator/system/camera/EmulatedCameraDevice.h
+++ b/tools/emulator/system/camera/EmulatedCameraDevice.h
@@ -356,7 +356,12 @@ protected:
             inline status_t startThread(bool one_burst)
             {
                 mOneBurst = one_burst;
-                return run(NULL, ANDROID_PRIORITY_URGENT_DISPLAY, 0);
+                status_t rv = run(NULL, ANDROID_PRIORITY_URGENT_DISPLAY, 0);
+                if (rv == INVALID_OPERATION) {
+                    stopThread();
+                    rv = run(NULL, ANDROID_PRIORITY_URGENT_DISPLAY, 0);
+                }
+                return rv;
             }
 
             /* Overriden base class method.

--- a/tools/emulator/system/camera/EmulatedFakeCameraDevice.cpp
+++ b/tools/emulator/system/camera/EmulatedFakeCameraDevice.cpp
@@ -240,6 +240,10 @@ bool EmulatedFakeCameraDevice::inWorkerThread()
 
 void EmulatedFakeCameraDevice::drawCheckerboard()
 {
+    if (mFrameWidth == 0) {
+        return;
+    }
+
     const int size = mFrameWidth / 10;
     bool black = true;
 


### PR DESCRIPTION
The change to EmulatedFakeCameraDevice.cpp prevents the SIGFPE crash; the change to EmulatedCameraDevice.h prevents the hang.
