### PR TITLE
Bug 1103782: don't stop/start thread at takePhoto when recording is on. ...

### DIFF
--- a/tools/emulator/system/camera/EmulatedCamera.cpp
+++ b/tools/emulator/system/camera/EmulatedCamera.cpp
@@ -345,6 +345,13 @@ status_t EmulatedCamera::takePicture()
         jpeg_quality = 90;  /* Fall back to default. */
     }
 
+    const bool recording_on = mCallbackNotifier.isVideoRecordingEnabled();
+    if (recording_on) {
+        mCallbackNotifier.setJpegQuality(jpeg_quality);
+        mCallbackNotifier.setTakingPicture(true);
+        return OK;
+    }
+
     /*
      * Make sure preview is not running, and device is stopped before taking
      * picture.


### PR DESCRIPTION
Bug 1103782:  Don't stop/start thread at takePhoto when recording is on. r=mikeh
